### PR TITLE
CouchDB backing

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Running the server
 
 Start the server with `node server.js`, then visit `localhost:8001` on your local dev box.
 
-Alternatively, if you're making changes to the server code, it's easier to use [Nodemon][nodemon] to automatically reload the server when you save the file. Run `npm install -g nodemon` to install it, then `nodemon server.js` to start the server.
+Alternatively, if you're making changes to the server code, it's easier to use [Nodemon][nodemon] to automatically reload the server when you save the file. Run `npm install -g nodemon` to install it, then `nodemon` to start the server.
 
 Branching
 =========

--- a/meeting_migrator.coffee
+++ b/meeting_migrator.coffee
@@ -1,0 +1,8 @@
+meetings = (require './data/meetings.js').meetings
+request = require 'request'
+couchUrl = process.env.COUCH_URL
+for meeting in meetings
+  do (meeting) ->
+    meeting.ISOString = new Date(meeting.date).toISOString()
+    request.put couchUrl+"/meetings/"+meeting.date, {json: meeting}, (e, r, body) ->
+      console.log body

--- a/package.json
+++ b/package.json
@@ -2,9 +2,10 @@
   "name": "sydjs",
   "version": "1.1.0",
   "private": true,
+  "main": "server.js",
   "engines": {
     "node": "0.8.x",
-    "npm":  "1.1.x"
+    "npm": "1.1.x"
   },
   "dependencies": {
     "express": "3.0.x",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "express": "3.0.x",
-    "hjs": "*"
+    "hjs": "*",
+    "request": "~2.12.0"
   }
 }

--- a/server.js
+++ b/server.js
@@ -2,6 +2,7 @@ process.env.TZ = 'Australia/Sydney';
 
 var express = require('express');
 var app = express();
+var request = require("request");
 
 app.set('port', process.env.PORT || 8001);
 app.set('views', __dirname + '/views');
@@ -9,6 +10,10 @@ app.use(express.logger('dev'));
 app.use(express.static(__dirname + '/static'));
 app.engine('html', require('hjs').__express);
 app.set('view engine', 'hjs');
+
+var couchUrl = process.env.COUCH_URL
+
+request.put(couchUrl+"/meetings");
 
 app.get('/timetest', function (req, res) {
     var now = new Date();
@@ -18,7 +23,9 @@ app.get('/timetest', function (req, res) {
 });
 
 app.get('/', function (req, res) {
-    res.render('index.html', getNextMeeting());
+    getNextMeeting(function(nextMeeting) {
+        res.render('index.html', nextMeeting);
+    });
 });
 
 app.use(function (req, res, next) {
@@ -35,8 +42,10 @@ app.listen(app.get('port'), function(){
     console.log('Server listening on port ' + app.get('port'));
 });
 
-function getNextMeeting() {
-    var meetings = require("./data/meetings").meetings,
+function getNextMeeting(cb) {
+
+    request.get(couchUrl+"/meetings/_design/meetings/_view/future_meetings", function(e, r, body) {
+        var meetings = JSON.parse(body).rows,
         index = meetings.length,
         data, meeting,
         startTime,
@@ -47,28 +56,31 @@ function getNextMeeting() {
             now.getMonth(),
             now.getDate()
         );
-    while (index--) {
-        meeting = meetings[index];
-        startTime = new Date(meeting.date);
-        if (startTime < prevMidnight) {
-            break;
+        while (index--) {
+            meeting = meetings[index].key;
+            startTime = new Date(meeting.date);
+            if (startTime < prevMidnight) {
+                break;
+            }
+            current = meeting;
         }
-        current = meeting;
-    }
-    startTime = new Date(current.date);
-    data = {
-        datetime: startTime.toString(),
-        datevalue: current.date + '+' + (-startTime.getTimezoneOffset() * 10 / 6),
-        presentations: []
-    };
-    current.speakers.forEach(function (speaker, i) {
-        data.presentations.push({
-            n: i + 1,
-            speaker: speaker.name,
-            speakerurl: speaker.twitter ? 'https://twitter.com/' + speaker.twitter : '',
-            topic: speaker.topic,
-            topicurl: speaker.link || ''
+        console.log(current);
+        startTime = new Date(current._id);
+        data = {
+            datetime: startTime.toString(),
+            datevalue: current._id + '+' + (-startTime.getTimezoneOffset() * 10 / 6),
+            presentations: []
+        };
+        current.speakers.forEach(function (speaker, i) {
+            data.presentations.push({
+                n: i + 1,
+                speaker: speaker.name,
+                speakerurl: speaker.twitter ? 'https://twitter.com/' + speaker.twitter : '',
+                topic: speaker.topic,
+                topicurl: speaker.link || ''
+            });
         });
+        console.log(data);
+        cb(data);
     });
-    return data;
 }

--- a/server.js
+++ b/server.js
@@ -14,6 +14,16 @@ app.set('view engine', 'hjs');
 var couchUrl = process.env.COUCH_URL
 
 request.put(couchUrl+"/meetings");
+var ddoc = {
+	"_id": "_design/meetings",
+	"language": "javascript",
+	"views": {
+		"future_meetings": {
+			"map": "function(doc) { if((doc.ISOString.localeCompare(new Date().toISOString()) > 0)){ emit(doc)}}"
+		}
+	}
+}
+request.put(couchUrl+"/meetings/_design/meetings", {json: ddoc});
 
 app.get('/timetest', function (req, res) {
     var now = new Date();


### PR DESCRIPTION
This is a light touch update doing the minimum possible to let the site back onto CouchDB. This is intended as the first step towards a web interface for adding and removing meetings.

To test it out for yourself, set the environment variable thusly (on OSX, other OSes YMMV)
COUCH_URL="https://temp:sydjs@sydjs.iriscouch.com" && export COUCH_URL

IrisCouch is free below $5 which I doubt we'll ever hit. http://www.iriscouch.com/service

If the hivemind decides this is the way to go I'll disable the temp user. If anyone wants to deploy this to Heroku hit me up and I'll give you all the details for the server admin user and the iriscouch account.
